### PR TITLE
HPOT-35: Local or Global Identification

### DIFF
--- a/hpotter-server/hpotter/TABLES_README.md
+++ b/hpotter-server/hpotter/TABLES_README.md
@@ -11,9 +11,9 @@ Both the `Credentials` and `Requests` tables have a relationship to the `Connect
 ### Connections Table
 The connections table has six columns:
 
-| id  | created_at | sourceIP | sourcePort | destPort | proto |
-|:---:|:----------:|:--------:|:----------:|:--------:|:-----:|
-| The primary key | Time of connection | Source IP of connection | Source port of connection | Destination port of connection | Protocol number, either TCP (6) or UDP (17) 
+| id  | created_at | sourceIP | sourcePort | destPort | localRemote | proto |
+|:---:|:----------:|:--------:|:----------:|:--------:|:-----------:|:-----:|
+| The primary key | Time of connection | Source IP of connection | Source port of connection | Destination port of connection | Whether IP address is from a private (local) or global (remote) network | Protocol number, either TCP (6) or UDP (17) 
 
 ### Credentials Table
 The credentials table stores the usernames and passwords used to log in via the Telnet and SSH services. The 

--- a/hpotter-server/hpotter/env.py
+++ b/hpotter-server/hpotter/env.py
@@ -5,6 +5,7 @@ import logging.config
 import platform
 import threading
 import docker
+import ipaddress
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy_utils import database_exists, create_database
@@ -108,6 +109,15 @@ def stop_shell():
     logger.info('Removing shell container')
     shell_container.remove()
     shell_container = None
+
+def getLocalRemote(sourceIP):
+    if ( ipaddress.ip_address(sourceIP).is_private ):
+        return "Local"
+    elif ( ipaddress.ip_address(sourceIP).is_global ):
+        return "Remote"
+    else:
+        #in case it's an unspecified / reserved etc.
+        return "Other" 
 
 jsonserverport = 8000
 

--- a/hpotter-server/hpotter/graphql/README.md
+++ b/hpotter-server/hpotter/graphql/README.md
@@ -28,6 +28,7 @@ query {
       sourceIP
       sourcePort
       destPort
+      localRemote
       proto
     }
     connectionsId

--- a/hpotter-server/hpotter/graphql/README.md
+++ b/hpotter-server/hpotter/graphql/README.md
@@ -28,7 +28,6 @@ query {
       sourceIP
       sourcePort
       destPort
-      localRemote
       proto
     }
     connectionsId

--- a/hpotter-server/hpotter/graphql/mutators.py
+++ b/hpotter-server/hpotter/graphql/mutators.py
@@ -10,6 +10,7 @@ class CreateConnection(graphene.Mutation):
         sourceIP = graphene.String()
         sourcePort = graphene.Int()
         destPort = graphene.Int()
+        localRemote = graphene.String()
         proto = graphene.Int()
 
     connection = graphene.Field(lambda: ConnectionsObject)
@@ -40,6 +41,7 @@ class UpdateConnection(graphene.Mutation):
         sourceIP = graphene.String()
         sourcePort = graphene.Int()
         destPort = graphene.Int()
+        localRemote = graphene.String()
         proto = graphene.Int()
 
     connection = graphene.Field(lambda: ConnectionsObject)
@@ -56,6 +58,9 @@ class UpdateConnection(graphene.Mutation):
         if 'destPort' in keys:
             session.query(Connections).filter(Connections.id == args['id']). \
                 update({Connections.destPort: args['destPort']})
+        if 'localRemote' in keys:
+            session.query(Connections).filter(Connections.id == args['id']). \
+                update({Connections.localRemote: args['localRemote']})
         if 'proto' in keys:
             session.query(Connections).filter(Connections.id == args['id']). \
                 update({Connections.proto: args['proto']})

--- a/hpotter-server/hpotter/graphql/schema.py
+++ b/hpotter-server/hpotter/graphql/schema.py
@@ -19,7 +19,7 @@ class Requests(SQLAlchemyObjectType):
 class Query(graphene.ObjectType):
     connection = graphene.Field(Connections, id=graphene.Int(), created_at=graphene.DateTime(),
                                 sourceIP=graphene.String(), sourcePort=graphene.Int(),
-                                destPort=graphene.Int(), proto=graphene.Int())
+                                destPort=graphene.Int(), localRemote=graphene.String(), proto=graphene.Int())
     connections = graphene.List(Connections)
 
     credential = graphene.Field(Credentials, id=graphene.Int(), username=graphene.String(),

--- a/hpotter-server/hpotter/plugins/generic.py
+++ b/hpotter-server/hpotter/plugins/generic.py
@@ -38,7 +38,7 @@ class OneWayThread(threading.Thread):
                 sourceIP=self.source.getsockname()[0],
                 sourcePort=self.source.getsockname()[1],
                 destPort=self.dest.getsockname()[1],
-                localRemote = getLocalRemote(addr[0]),
+                localRemote = getLocalRemote(self.source.getsockname()[0]),
                 proto=tables.TCP)
             write_db(self.connection)
         

--- a/hpotter-server/hpotter/plugins/generic.py
+++ b/hpotter-server/hpotter/plugins/generic.py
@@ -2,7 +2,7 @@ import socket, ssl
 import threading
 
 from hpotter import tables
-from hpotter.env import logger, write_db
+from hpotter.env import logger, write_db, getLocalRemote
 
 # remember to put name in __init__.py
 
@@ -38,6 +38,7 @@ class OneWayThread(threading.Thread):
                 sourceIP=self.source.getsockname()[0],
                 sourcePort=self.source.getsockname()[1],
                 destPort=self.dest.getsockname()[1],
+                localRemote = getLocalRemote(addr[0]),
                 proto=tables.TCP)
             write_db(self.connection)
         

--- a/hpotter-server/hpotter/plugins/ssh.py
+++ b/hpotter-server/hpotter/plugins/ssh.py
@@ -8,7 +8,7 @@ import _thread
 
 import hpotter.env
 from hpotter import tables
-from hpotter.env import logger, write_db, ssh_server
+from hpotter.env import logger, write_db, ssh_server, getLocalRemote
 from hpotter.docker_shell.shell import fake_shell
 
 class SSHServer(paramiko.ServerInterface):
@@ -96,6 +96,7 @@ class SshThread(threading.Thread):
                 sourceIP=addr[0],
                 sourcePort=addr[1],
                 destPort=self.ssh_socket.getsockname()[1],
+                localRemote = getLocalRemote(addr[0]),
                 proto=tables.TCP)
             write_db(connection)
 

--- a/hpotter-server/hpotter/plugins/telnet.py
+++ b/hpotter-server/hpotter/plugins/telnet.py
@@ -34,7 +34,7 @@ class TelnetHandler(socketserver.BaseRequestHandler):
             sourceIP=self.client_address[0],
             sourcePort=self.client_address[1],
             destPort=self.server.socket.getsockname()[1],
-            localRemote = getLocalRemote(addr[0]),
+            localRemote = getLocalRemote(self.client_address[0]),
             proto=tables.TCP)
         write_db(connection)
 

--- a/hpotter-server/hpotter/plugins/telnet.py
+++ b/hpotter-server/hpotter/plugins/telnet.py
@@ -3,7 +3,7 @@ import threading
 
 from hpotter import tables
 from hpotter.tables import CREDS_LENGTH
-from hpotter.env import logger, write_db, telnet_server
+from hpotter.env import logger, write_db, telnet_server, getLocalRemote
 from hpotter.docker_shell.shell import fake_shell, get_string
 
 # https://docs.python.org/3/library/socketserver.html
@@ -34,6 +34,7 @@ class TelnetHandler(socketserver.BaseRequestHandler):
             sourceIP=self.client_address[0],
             sourcePort=self.client_address[1],
             destPort=self.server.socket.getsockname()[1],
+            localRemote = getLocalRemote(addr[0]),
             proto=tables.TCP)
         write_db(connection)
 

--- a/hpotter-server/hpotter/tables.py
+++ b/hpotter-server/hpotter/tables.py
@@ -24,6 +24,7 @@ class Connections(Base):
     sourceIP = Column(String)
     sourcePort = Column(Integer)
     destPort = Column(Integer)
+    localRemote = Column(String)
     proto = Column(Integer)
 
 

--- a/hpotter-server/hpotter/test/test_env.py
+++ b/hpotter-server/hpotter/test/test_env.py
@@ -1,0 +1,17 @@
+import unittest
+import ipaddress
+from hpotter.env import getLocalRemote
+
+class TestEnv (unittest.TestCase):
+    def test_localRemote(self):
+        
+        #Don't know if I should relabel the outputs from getLocalRemote to Private and Global instead
+        
+        self.assertEqual(getLocalRemote(ipaddress.ip_address('103.11.49.181')), "Remote")
+        self.assertEqual(getLocalRemote(ipaddress.ip_address('67.174.103.180')), "Remote")
+        self.assertEqual(getLocalRemote(ipaddress.ip_address('127.0.0.1')), "Local")
+        self.assertEqual(getLocalRemote(ipaddress.ip_address('123.207.40.81')), "Remote")
+        self.assertEqual(getLocalRemote(ipaddress.ip_address('192.168.1.2')), "Local")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
implemented ipaddress module and added getLocalRemote function to env.py.  changed ssh, telnet tables and generic.py files to add localRemote to connections table.  Let me know if we don't want to change the tables so I can change it to just pass a string instead and we can change the developer tag to get that.